### PR TITLE
Fix various BNW 2.1 incompatibilities

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ Source rom file:
         FF3 SNES NA 1.0     e986575b98300f721ce27c180264d890
         FF6 SFC JP          97bf78e916b80f47cf35edf502be34dc
         FF6 BNW 1.9         54427dfadea94ef32acd77be78137ac5
-        FF6 BNW 2.1-14b     180de30b6171dde23ce865eaf0b77324
+        FF6 BNW 2.1         b58f799ee291dbc58c08f3b457e35a22
     Other FF6 SNES mods, such as Beyond Chaos seeds, might also be compatible by selecting "FF6_NA_SAFE_MODE" when prompted.
 
 Seed value:

--- a/tables/command_shuffle_patch_bnw2.txt
+++ b/tables/command_shuffle_patch_bnw2.txt
@@ -1,8 +1,8 @@
-0fa5ab: fc 01 00 1b  # Nimufu
-0fb2c4: fc 01 00 05  # Merchant
-0fbed1: fc 01 00 05  # Trooper
-0f9e76: fc 01 00 0a  # Vargas
-0faf37: fc 01 00 0d  # Ultros
+0fa5ac: fc 01 00 1b  # Nimufu
+0fb2c5: fc 01 00 05  # Merchant
+0fbed2: fc 01 00 05  # Trooper
+0f9e77: fc 01 00 0a  # Vargas
+0faf38: fc 01 00 0d  # Ultros
 
 0236e4: ea ea f4 00 00 f4 00 00  # lore
 025ee8: ea ea                    # dance
@@ -21,11 +21,11 @@
 
 VALIDATION
 
-0fa5ab: fc 01 1b 1b  # Nimufu
-0fb2c4: fc 01 05 05  # Merchant
-0fbed1: fc 01 05 05  # Trooper
-0f9e76: fc 02 5d 5d  # Vargas
-0faf37: fc 02 86 d0  # Ultros
+0fa5ac: fc 01 1b 1b  # Nimufu
+0fb2c5: fc 01 05 05  # Merchant
+0fbed2: fc 01 05 05  # Trooper
+0f9e77: fc 02 5d 5d  # Vargas
+0faf38: fc 02 86 d0  # Ultros
 
 0236e4: 30 22 f4 c3 b0 f4 10 23  # lore
 025ee8: 30 16                    # dance

--- a/tables/magicite_pointers_bnw2.txt
+++ b/tables/magicite_pointers_bnw2.txt
@@ -13,8 +13,8 @@ c1f85
 a00e1
 b9a7c
 
-# crusader
-cfe4b
+# ragnarok
+b52d7
 c2044
 
 c521c

--- a/tables/master.txt
+++ b/tables/master.txt
@@ -4,4 +4,4 @@ FF6_NA_1.0          e986575b98300f721ce27c180264d890    tables_list.txt
 #FF6_NA_1.1          544311e104805e926083acf29ec664da    tables_list.txt
 FF6_JP              97bf78e916b80f47cf35edf502be34dc    tables_list_jp.txt
 FF6_BNW_1.9         54427dfadea94ef32acd77be78137ac5    tables_list_bnw.txt
-FF6_BNW_2.1-14b     180de30b6171dde23ce865eaf0b77324    tables_list_bnw2.txt
+FF6_BNW_2.1         b58f799ee291dbc58c08f3b457e35a22    tables_list_bnw2.txt

--- a/tables/tables_list_bnw2.txt
+++ b/tables/tables_list_bnw2.txt
@@ -113,6 +113,7 @@ $aux_seed_length            19
 .patch                      flip_gradient_patch.txt
 .patch                      splash_removal_patch.txt
 .patch                      opening_skip_patch.txt
+.patch                      undo_kagenui_skip_patch.txt
 .option                     textless_patch_bnw2.txt
 .option                     myself_core_patch.bin
 #.option                     myself_menu_dance_patch.txt

--- a/tables/textless_patch_bnw2.txt
+++ b/tables/textless_patch_bnw2.txt
@@ -3,22 +3,19 @@
 0098f0: e2
 009966: 94 da
 00a49f: 60 ff ff ff ff ff ff
-00a4bc: 20 75 a4 85 ba a9 03 4c 5c 9b 20 75 a4 85 ba a9 01 85 eb a9 00 85 ec 85 ed a9 03 4c a3 b1 20 ed a4 d0 0b 4c bc a4 20 ed a4 d0 03 4c c6 a4 4c 50 da 7b 20 1d da c9 ff 60 ff ff ff ff ff
+00a4bc: 20 75 a4 85 ba a9 03 4c 5c 9b 20 75 a4 85 ba a9 01 85 eb a9 00 85 ec 85 ed a9 03 4c a3 b1 20 ed a4 d0 0b 4c bc a4 20 ed a4 d0 03 4c c6 a4 4c 69 db 7b 20 36 db c9 ff 60 ff ff ff ff ff
 00add2: 60 ff ff ff ff
-00da17: ad 4e 1d 89 20 60 5a 20 17 da d0 1d 20 46 da f0 18 20 75 a4 a4 00 b7 c9 f0 13 c9 15 f0 0b c9 19 f0 07 c9 1a f0 03 c8 80 ed a9
-00da42: 80 00 7a 60 c2 20 a5 82 c9 94 01 e2 20 60 64 d0 64 bc 9c 64 05 64 cb 64 c9 9c 68 05 4c c1 a4 e2 10 7b aa c2 20 a9 00 01 48 2b b5 02 9d 83 4d b5 06 9d 87 4d b5 0a 9d 8b 4d b5 0e 9d 8f 4d 8a 18 69 10 00 aa e0 c0 d0 e1 a9 00 00 48 2b e2 20 c2 10 6b 20 17 da d0 32 c2 20 a9 d3 da 85 c9 e2 20 7b a9 c0 85 cb a9 01 8d 68 05 a9 01 85 bc 85 ba a5 eb 38 e9 36 85 40 20 bd ad a9 01 85 eb a9 00 85 ec 85 ed a9 02 4c a3 b1 20 bd ad a9 02 4c 5c 9b 01 14 04 26 48 84 83 80 d4 40 42 3c a5 80 73 1b 62 00
-00ffdc: 61 d6 9e 29
+00db30: ad 4e 1d 89 20 60 5a 20 30 db d0 1d 20 5f db f0 18 20 75 a4 a4 00 b7 c9 f0 13 c9 15 f0 0b c9 19 f0 07 c9 1a f0 03 c8 80 ed a9 ff 80 00 7a 60 c2 20 a5 82 c9 94 01 e2 20 60 64 d0 64 bc 9c 64 05 64 cb 64 c9 9c 68 05 4c c1 a4 e2 10 7b aa c2 20 a9 00 01 48 2b b5 02 9d 83 4d b5 06 9d 87 4d b5 0a 9d 8b 4d b5 0e 9d 8f 4d 8a 18 69 10 00 aa e0 c0 d0 e2 a9 00 00 48 2b e2 20 c2 10 6b 20 30 db d0 32 c2 20 a9 ec db 85 c9 e2 20 7b a9 c0 85 cb a9 01 8d 68 05 a9 01 85 bc 85 ba a5 eb 38 e9 36 85 40 20 bd ad a9 01 85 eb a9 00 85 ec 85 ed a9 02 4c a3 b1 20 b8 ad a9 02 4c 5c 9b 01 14 04 26 48 84 83 80 d4 40 42 3c a5 80 73 1b 62 00
 0196d6: 22 61 da c0 20 2a 02 60 ad 4e 1d 89 20 60 20 de 96 d0 05 e6 8f 4c 47 ff 4c c1 96 20 de 96 d0 03 4c 47 ff 4c 12 43 20 de 96 d0 03 4c 47 ff 4c ad 96 ff ff ff ff ff
 01fdc0: e4
-01fdde: fc
-01fde0: f1
+01fdde: fc 96
+01fde0: f1 96
 030068: 80
 033ca1: 45
 033caa: 40
 033e20: ea ea ea ea
 033e2f: ea ea ea ea ea
-034940: 35
-034942: 8e a7 00 25 3c 8e 9f 9f 00
+034940: 35 3c 8e a7 00 25 3c 8e 9f 9f 00
 0349e1: 93 9e b1 ad 00
 
 VALIDATION
@@ -30,18 +27,15 @@ VALIDATION
 00a49f: 85 ba a9 03 4c 5c 9b
 00a4bc: c2 20 a5 eb 29 ff 1f 85 d0 7b e2 20 a5 ec 30 04 a9 01 80 02 a9 12 85 bc a5 ec 29 40 4a 4a 4a 4a 4a 4a 8d 64 05 20 bf 7f a9 01 85 ba a9 01 85 eb a9 00 85 ec a9 00 85 ed a9 03 4c a3 b1
 00add2: a9 02 4c 5c 9b
-00da17: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
-00da42: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
-00ffdc: 62 7c 9d 83
+00db30: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
 0196d6: e2 10 7b aa c2 20 a9 00 01 48 2b b5 02 9d 83 4d b5 06 9d 87 4d b5 0a 9d 8b 4d b5 0e 9d 8f 4d 8a 18 69 10 00 aa e0 c0 d0 e2 a9 00 00 48 2b e2 20 c2 10 20 2a 02 60
 01fdc0: c1
-01fdde: ad
-01fde0: aa
+01fdde: ad 96
+01fde0: aa 96
 030068: f0
 033ca1: 40
 033caa: 49
 033e20: 7b 20 3f 3e
 033e2f: a9 ff 20 3f 3e
-034940: 25
-034942: 92 ad 9e ab 9e a8 00 35 3c
+034940: 25 3c 92 ad 9e ab 9e a8 00 35 3c
 0349e1: 92 a8 ae a7 9d

--- a/tables/undo_kagenui_skip_patch.txt
+++ b/tables/undo_kagenui_skip_patch.txt
@@ -1,0 +1,7 @@
+0b52e4: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+0b7a7c: 42 14 3e 14 
+
+VALIDATION
+
+0b52e4: 42 14 3e 14 c0 a3 00 f2 52 01 81 29 80 02 fe
+0b7a7c: b2 e4 52 01


### PR DESCRIPTION
There's a few stale references in BC:G as of the last few beta iterations of BNW 2.1, and this PR addresses at least a few of them of which I am aware:
- new AI script offsets for command shuffler (shifted 1 byte down)
- new freespace location for no-text patch (closes #6)
- new event bank address for Ragnarok magicite
- antipatch for an inventory manipulation event hack that removes/adds specific items after Intangir fight if Shadow is dead

There may be other 2.1 issues to be found; I'll round them up in another PR if I think of any.

Please note that I've been unable to actually run the randomizer to confirm that these edits are working as intended – see conversation [here](https://discord.com/channels/160240476883124225/825016725375549551/972941200199913502). At a minimum, I can at least confirm that the no-text patch applies correctly now and does not immediately crash at the first dialogue.